### PR TITLE
Add new narrow search options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3163,10 +3163,93 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "requires": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/core": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
     "@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "requires": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+        }
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -4708,6 +4791,30 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-emotion": {
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
@@ -4785,6 +4892,11 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.6.tgz",
       "integrity": "sha512-1aGDUfL1qOOIoqk9QKGIo2lANk+C7ko/fqH0uIyC71x3PEGz0uVP8ISgfEsFuG+FKmjHTvFK/nNM8dowpmUxLA=="
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -7759,6 +7871,11 @@
         "pkg-dir": "^3.0.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -8010,7 +8127,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8028,11 +8146,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8045,15 +8165,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8156,7 +8279,8 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8166,6 +8290,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8178,17 +8303,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8205,6 +8333,7 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -8260,7 +8389,8 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -8285,7 +8415,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8295,6 +8426,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8363,7 +8495,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8393,6 +8526,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8410,6 +8544,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8448,11 +8583,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -10568,6 +10705,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -13210,6 +13352,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
+    "react-input-autosize": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -13374,6 +13524,21 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
+      }
+    },
+    "react-select": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.1.1.tgz",
+      "integrity": "sha512-HjC6jT2BhUxbIbxMZWqVcDibrEpdUJCfGicN0MMV+BQyKtCaPTgFekKWiOizSCy4jdsLMGjLqcFGJMhVGWB0Dg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/cache": "^10.0.9",
+        "@emotion/core": "^10.0.9",
+        "@emotion/css": "^10.0.9",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "react-input-autosize": "^2.2.2",
+        "react-transition-group": "^4.3.0"
       }
     },
     "react-transition-group": {
@@ -15950,7 +16115,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-load-script": "0.0.6",
     "react-places-autocomplete": "^7.3.0",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "3.4.3"
+    "react-scripts": "3.4.3",
+    "react-select": "^3.1.1"
   },
   "scripts": {
     "start": "./node_modules/react-scripts/bin/react-scripts.js start && nodemon server/server.js",

--- a/src/App.css
+++ b/src/App.css
@@ -51,7 +51,9 @@
 }
 
 #body-wrapper {
-  flex: 1
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 #footer {

--- a/src/components/FindResource/FindResource.css
+++ b/src/components/FindResource/FindResource.css
@@ -36,7 +36,6 @@
 }
 
 .narrow-search-field-card {
-  border: 1px solid #929292;
   box-sizing: border-box;
   display: flex;
   margin-bottom: 10px;
@@ -46,17 +45,6 @@
 
 .narrow-search-field-title {
   width: 200px;
-}
-
-#pill-button {
-  border: none;
-  padding: 10px 20px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  margin: 4px 2px;
-  cursor: pointer;
-  border-radius: 16px;
 }
 
 #card-home-blurb-container {

--- a/src/components/FindResource/FindResource.css
+++ b/src/components/FindResource/FindResource.css
@@ -82,9 +82,16 @@
   background-color: #8D9DF9;
 }
 
-.results-container {
-  height: 81vh;
+.FindResource {
+  flex: 1;
   display: flex;
+  flex-direction: column;
+}
+
+.results-container {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
 }
 
 .left-panel {

--- a/src/components/FindResource/FindResource.js
+++ b/src/components/FindResource/FindResource.js
@@ -213,35 +213,35 @@ class FindResource extends React.Component {
         <Card.Body className="narrow-search-field-card" style={{'marginTop': '10px'}}>
           <Container>
             <Row>
-              <Col md={4}>Prevention:</Col>
+              <Col lg={6} xl={4}>Prevention:</Col>
               <Col><Select closeMenuOnSelect={false} isMulti options={preventionOptions} onChange={e => this.handleNarrowSearchChange('Prevention', e)} /></Col>
             </Row>
             <Row>
-              <Col md={4}>Transportation:</Col>
+              <Col lg={6} xl={4}>Transportation:</Col>
               <Col><Select closeMenuOnSelect={false} isMulti options={transportOptions} onChange={e => this.handleNarrowSearchChange('Transportation', e)} /></Col>
             </Row>
             <Row>
-              <Col md={4}>Recovery:</Col>
+              <Col lg={6} xl={4}>Recovery:</Col>
               <Col><Select closeMenuOnSelect={false} isMulti options={recoveryOptions} onChange={e => this.handleNarrowSearchChange('Recovery', e)} /></Col>
             </Row>
             <Row>
-              <Col md={4}>Mental Health Resources:</Col>
+              <Col lg={6} xl={4}>Mental Health Resources:</Col>
               <Col><Select closeMenuOnSelect={false} isMulti options={mentalHealthOptions} onChange={e => this.handleNarrowSearchChange('Mental Health Resources', e)} /></Col>
             </Row>
             <Row>
-              <Col md={4}>Payment:</Col>
+              <Col lg={6} xl={4}>Payment:</Col>
               <Col><Select closeMenuOnSelect={false} isMulti options={payOptions} onChange={e => this.handleNarrowSearchChange('Payment', e)} /></Col>
             </Row>
             <Row>
-              <Col md={4}>Harm Reduction:</Col>
+              <Col lg={6} xl={4}>Harm Reduction:</Col>
               <Col><Select closeMenuOnSelect={false} isMulti options={harmReductionOptions} onChange={e => this.handleNarrowSearchChange('Harm Reduction', e)} /></Col>
             </Row>
             <Row>
-              <Col md={4}>Pregnancy Support:</Col>
+              <Col lg={6} xl={4}>Pregnancy Support:</Col>
               <Col><Select closeMenuOnSelect={false} isMulti options={pregnancyOptions} onChange={e => this.handleNarrowSearchChange('Pregnancy Support', e)} /></Col>
             </Row>
             <Row>
-              <Col md={4}>Demographic:</Col>
+              <Col lg={6} xl={4}>Demographic:</Col>
               <Col><Select closeMenuOnSelect={false} isMulti options={demographicOptions} onChange={e => this.handleNarrowSearchChange('Demographic', e)} /></Col>
             </Row>
           </Container>
@@ -354,7 +354,7 @@ class FindResource extends React.Component {
             </Row>
             <Row className="justify-content-md-center">
               <Col xs={12} sm={12} md={6} lg={6} className="narrow-search-button-col">
-                <Button className="justify-content-md-start shadow-none" id="narrow-search-button" onClick={() => this.setState({showNarrowSearch: !this.state.showNarrowSearch})}>Narrow Search >></Button>
+                <Button className="justify-content-md-start shadow-none" id="narrow-search-button" onClick={() => this.setState({showNarrowSearch: !this.state.showNarrowSearch})}>Narrow Search &gt;&gt;</Button>
               </Col>
             </Row>
             <Row className="justify-content-md-center">

--- a/src/components/FindResource/FindResource.js
+++ b/src/components/FindResource/FindResource.js
@@ -31,82 +31,6 @@ class FindResource extends React.Component {
     }
   }
 
-  renderResourceTypeButton = (text) => {
-    const { narrowSearchOptions } = this.state;
-    const {resourceTypeSelection } = narrowSearchOptions;
-
-    const buttonStyle = {
-      'backgroundColor': resourceTypeSelection.includes(text) ? '#8D9DF9' : '#DEDEDE',
-      'color': resourceTypeSelection.includes(text) ? 'white' : 'black'
-    }
-
-    const handleResourceTypeButtonClick = () => {
-      const { narrowSearchOptions } = this.state;
-      const { resourceTypeSelection } = narrowSearchOptions;
-
-      const updatedResourceTypes = resourceTypeSelection.includes(text) ? narrowSearchOptions.resourceTypeSelection.filter(type => type !== text) : narrowSearchOptions.resourceTypeSelection.concat(text)
-
-      this.setState({
-        narrowSearchOptions: {
-          ...narrowSearchOptions,
-          resourceTypeSelection: updatedResourceTypes
-        }
-      });
-    }
-
-    return (
-      <Button className="shadow-none" id="pill-button" onClick={handleResourceTypeButtonClick} style={buttonStyle}>{text}</Button>
-    );
-  }
-
-  renderTransportationButton = (text) => {
-    const { narrowSearchOptions } = this.state;
-    const { transportationSelection } = narrowSearchOptions;
-
-    const buttonStyle = {
-      'backgroundColor': transportationSelection.includes(text) ? '#8D9DF9' : '#DEDEDE',
-      'color': transportationSelection.includes(text) ? 'white' : 'black'
-    }
-
-    const handleTransportationButtonClick = () => {
-      const updatedTransportationSelection = transportationSelection.includes(text) ? transportationSelection.filter(type => type !== text) : transportationSelection.concat(text)
-      this.setState({
-        narrowSearchOptions: {
-          ...narrowSearchOptions,
-          transportationSelection: updatedTransportationSelection
-        }
-      });
-    }
-
-    return (
-      <Button className="shadow-none" id="pill-button" onClick={handleTransportationButtonClick} style={buttonStyle}>{text}</Button>
-    );
-  }
-
-  renderDemographicButton = (text) => {
-    const { narrowSearchOptions } = this.state;
-    const { demographicSelection } = narrowSearchOptions;
-
-    const buttonStyle = {
-      'backgroundColor': demographicSelection.includes(text) ? '#8D9DF9' : '#DEDEDE',
-      'color': narrowSearchOptions.demographicSelection.includes(text) ? 'white' : 'black'
-    }
-
-    const handleDemographicButtonClick = () => {
-      const updatedDemographicSelection = demographicSelection.includes(text) ? demographicSelection.filter(type => type !== text) : demographicSelection.concat(text)
-      this.setState({
-        narrowSearchOptions: {
-          ...narrowSearchOptions,
-          demographicSelection: updatedDemographicSelection
-        }
-      });
-    }
-
-    return (
-      <Button className="shadow-none" id="pill-button" onClick={handleDemographicButtonClick} style={buttonStyle}>{text}</Button>
-    );
-  }
-
   handleMileDropdownChange = event => {
     const { narrowSearchOptions } = this.state;
 
@@ -133,6 +57,9 @@ class FindResource extends React.Component {
       { value: 'Political Advocacy', label: 'Political Advocacy' },
     ]
     const transportOptions = [
+      { value: 'Bus', label: 'Bus' },
+      { value: 'Metro', label: 'Metro' },
+      { value: 'Center-Provided', label: 'Center-Provided' },
       { value: 'Transportation to Services', label: 'Transportation to Services' },
     ]
     const recoveryOptions = [
@@ -244,32 +171,22 @@ class FindResource extends React.Component {
               <Col lg={6} xl={4}>Demographic:</Col>
               <Col><Select closeMenuOnSelect={false} isMulti options={demographicOptions} onChange={e => this.handleNarrowSearchChange('Demographic', e)} /></Col>
             </Row>
+            <Row style={{'marginTop': '20px'}}>
+              <Col xs xl={4}>Distance in Miles:</Col>
+              <Col xs="auto">
+                <Form>
+                  <Form.Group controlId="exampleForm.SelectCustom">
+                    <Form.Control as="select" value={distanceInMilesSelection} onChange={this.handleMileDropdownChange} custom>
+                      <option>5</option>
+                      <option>10</option>
+                      <option>25</option>
+                      <option>50</option>
+                    </Form.Control>
+                  </Form.Group>
+                </Form>
+              </Col>
+            </Row>
           </Container>
-        </Card.Body>
-        <Card.Body className="narrow-search-field-card">
-          <div style={{'flexDirection': 'column'}}>
-            <div style={{'display': 'flex'}}>
-              <div className="narrow-search-field-title">Distance in Miles</div>
-              <Form>
-                <Form.Group controlId="exampleForm.SelectCustom">
-                  <Form.Control as="select" value={distanceInMilesSelection} onChange={this.handleMileDropdownChange} custom>
-                    <option>5</option>
-                    <option>10</option>
-                    <option>25</option>
-                    <option>50</option>
-                  </Form.Control>
-                </Form.Group>
-              </Form>
-            </div>
-            <div style={{'display': 'flex'}}>
-              <div className="narrow-search-field-title">Transportation</div>
-              <div>
-                {this.renderTransportationButton('Bus')}
-                {this.renderTransportationButton('Metro')}
-                {this.renderTransportationButton('Center-Provided')}
-              </div>
-            </div>
-          </div>
         </Card.Body>
       </Card>
     );

--- a/src/components/FindResource/FindResource.js
+++ b/src/components/FindResource/FindResource.js
@@ -11,6 +11,7 @@ import Button from 'react-bootstrap/Button';
 import Nav from 'react-bootstrap/Nav';
 import SearchResultLeftPanel from '../SearchResultLeftPanel/SearchResultLeftPanel';
 import SearchResultRightPanel from '../SearchResultRightPanel/SearchResultRightPanel';
+import Select from 'react-select'
 
 import './FindResource.css';
 
@@ -105,23 +106,130 @@ class FindResource extends React.Component {
       <Button className="shadow-none" id="pill-button" onClick={handleDemographicButtonClick} style={buttonStyle}>{text}</Button>
     );
   }
-  
+
   handleMileDropdownChange = event => {
     const { narrowSearchOptions } = this.state;
 
     this.setState({
       narrowSearchOptions: {
         ...narrowSearchOptions,
-        distanceInMiles: parseInt(event.target.value)
+        distanceInMilesSelection: parseInt(event.target.value)
       }
     });
   }
 
+  handleNarrowSearchChange = (category, event) => {
+    const { narrowSearchOptions } = this.state;
+    narrowSearchOptions[category] = event.map(x => x.value);
+    this.setState(narrowSearchOptions);
+  }
+
   renderNarrowSearch = () => {
     const { narrowSearchOptions } = this.state;
-    const { distanceInMiles } = narrowSearchOptions;
+    const { distanceInMilesSelection } = narrowSearchOptions;
+    const preventionOptions = [
+      { value: 'Awareness and Education', label: 'Awareness and Education' },
+      { value: 'Physician Education', label: 'Physician Education' },
+      { value: 'Political Advocacy', label: 'Political Advocacy' },
+    ]
+    const transportOptions = [
+      { value: 'Transportation to Services', label: 'Transportation to Services' },
+    ]
+    const recoveryOptions = [
+      { value: 'Medicated Assisted Treatment', label: 'Medicated Assisted Treatment' },
+      { value: 'Nutrition', label: 'Nutrition' },
+      { value: 'Inpatient Rehabilitation', label: 'Inpatient Rehabilitation' },
+      { value: 'Intervention Specialists', label: 'Intervention Specialists' },
+      { value: 'Luxury Treatment', label: 'Luxury Treatment' },
+      { value: 'Faith-based Rehabilitation', label: 'Faith-based Rehabilitation' },
+      { value: 'Support Groups', label: 'Support Groups' },
+      { value: 'Outpatient Rehabilitation', label: 'Outpatient Rehabilitation',
+        options: [
+          { value: 'Day Programs', label: 'Day Programs' },
+          { value: 'Intensive Outpatient Programs', label: 'Intensive Outpatient Programs' },
+          { value: 'Continuing Care', label: 'Continuing Care' },
+        ],
+      },
+      { value: 'Gender-Specific Treatment', label: 'Gender-Specific Treatment',
+        options: [
+          { value: 'Men', label: 'Men' },
+          { value: 'Women', label: 'Women' },
+          { value: 'Non-binary', label: 'Non-binary' },
+        ],
+      },
+      { value: 'Recovery Residences', label: 'Recovery Residences',
+        options: [
+          { value: 'Level 1: Peer Run', label: 'Level 1: Peer Run' },
+          { value: 'Level 2: Monitored', label: 'Level 2: Monitored' },
+          { value: 'Level 3: Supervised', label: 'Level 3: Supervised' },
+          { value: 'Level 4: Service Provider', label: 'Level 4: Service Provider' },
+        ],
+      },
+    ]
+    const mentalHealthOptions = [
+      { value: 'Counseling', label: 'Counseling' },
+      { value: 'Family Therapy', label: 'Family Therapy' },
+      { value: 'Holistic Therapy', label: 'Holistic Therapy' },
+      { value: 'Support Groups', label: 'Support Groups' },
+    ]
+    const payOptions = [
+          { value: 'Sliding Scale', label: 'Sliding Scale' },
+          { value: 'Free', label: 'Free' },
+          { value: 'Paid', label: 'Paid' },
+    ]
+    const harmReductionOptions = [
+      { value: 'Needle Exchange Programs', label: 'Needle Exchange Programs' },
+      { value: 'Needle Injection Sites', label: 'Needle Injection Sites' },
+      { value: 'Overdose Response', label: 'Overdose Response',
+        options: [
+          { value: 'Naloxone Distributor', label: 'Naloxone Distributor' },
+          { value: 'Overdose Response Trainer', label: 'Overdose Response Trainer' },
+        ],
+      },
+      { value: 'Needle-Transmitted Diseases', label: 'Needle-Transmitted Diseases',
+        options: [
+          { value: 'HIV Pre-Exposure Prophylaxis', label: 'HIV Pre-Exposure Prophylaxis' },
+          { value: 'HIV Post-Exposure Prophylaxis', label: 'HIV Post-Exposure Prophylaxis' },
+          { value: 'Vaccine Clinics', label: 'Vaccine Clinics' },
+        ],
+      },
+    ]
+    const pregnancyOptions = [
+      { value: 'Pregnancy Support', label: 'Pregnancy Support' },
+    ]
+    const demographicOptions = [
+      { value: 'Adults', label: 'Adults' },
+      { value: 'LGBTQ+', label: 'LGBTQ+' },
+      { value: 'Veterans', label: 'Veterans' },
+      { value: 'Seniors', label: 'Seniors' },
+      { value: 'Children', label: 'Children' },
+      { value: 'Adolescents', label: 'Adolescents' },
+      { value: 'Young Adults', label: 'Young Adults' },
+      { value: 'Homeless', label: 'Homeless' },
+    ]
     return (
       <Card className="narrow-search-card">
+        <Card.Body className="narrow-search-field-card" style={{'marginTop': '10px'}}>
+          <div className="narrow-search-field-title"> New Options:</div>
+          <div style={{'flex': '1', 'marginRight': '5%'}}>
+            Prevention:
+            <Select closeMenuOnSelect={false} isMulti options={preventionOptions} onChange={e => this.handleNarrowSearchChange('Prevention', e)} />
+            Transportation:
+            <Select closeMenuOnSelect={false} isMulti options={transportOptions} onChange={e => this.handleNarrowSearchChange('Transportation', e)} />
+            Recovery:
+            <Select closeMenuOnSelect={false} isMulti options={recoveryOptions} onChange={e => this.handleNarrowSearchChange('Recovery', e)} />
+            Mental Health Resources:
+            <Select closeMenuOnSelect={false} isMulti options={mentalHealthOptions} onChange={e => this.handleNarrowSearchChange('Mental Health Resources', e)} />
+            Payment:
+            <Select closeMenuOnSelect={false} isMulti options={payOptions} onChange={e => this.handleNarrowSearchChange('Payment', e)} />
+            Harm Reduction:
+            <Select closeMenuOnSelect={false} isMulti options={harmReductionOptions} onChange={e => this.handleNarrowSearchChange('Harm Reduction', e)} />
+            Pregnancy Support:
+            <Select closeMenuOnSelect={false} isMulti options={pregnancyOptions} onChange={e => this.handleNarrowSearchChange('Pregnancy Support', e)} />
+            Demographic:
+            <Select closeMenuOnSelect={false} isMulti options={demographicOptions} onChange={e => this.handleNarrowSearchChange('Demographic', e)} />
+          </div>
+        </Card.Body>
         <Card.Body className="narrow-search-field-card" style={{'marginTop': '10px'}}>
           <div className="narrow-search-field-title"> Resource Type:<br/>(select multiple bubbles)</div>
           <div>
@@ -148,7 +256,7 @@ class FindResource extends React.Component {
               <div className="narrow-search-field-title">Distance in Miles</div>
               <Form>
                 <Form.Group controlId="exampleForm.SelectCustom">
-                  <Form.Control as="select" value={distanceInMiles} onChange={this.handleMileDropdownChange} custom>
+                  <Form.Control as="select" value={distanceInMilesSelection} onChange={this.handleMileDropdownChange} custom>
                     <option>5</option>
                     <option>10</option>
                     <option>25</option>
@@ -240,10 +348,10 @@ class FindResource extends React.Component {
             </Row>
             <Row className="justify-content-md-center">
               <Col xs={12} sm={12} md={6} lg={6} style={{'marginTop': '20px', 'float': 'left'}}>
-                <Script 
+                <Script
                   url={`https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_GOOGLE_API_KEY}&libraries=places`}
-                  onLoad={this.handleScriptLoad}        
-                />  
+                  onLoad={this.handleScriptLoad}
+                />
                 {
                   // wasn't able to get search icon to work so I'm replacing the close icon as the search icon
                   // onChange reset query since we don't want to query for an invalid location

--- a/src/components/FindResource/FindResource.js
+++ b/src/components/FindResource/FindResource.js
@@ -120,7 +120,7 @@ class FindResource extends React.Component {
 
   handleNarrowSearchChange = (category, event) => {
     const { narrowSearchOptions } = this.state;
-    narrowSearchOptions[category] = event.map(x => x.value);
+    narrowSearchOptions[category] = event == null ? [] : event.map(x => x.value);
     this.setState(narrowSearchOptions);
   }
 
@@ -207,48 +207,44 @@ class FindResource extends React.Component {
       { value: 'Young Adults', label: 'Young Adults' },
       { value: 'Homeless', label: 'Homeless' },
     ]
+
     return (
       <Card className="narrow-search-card">
         <Card.Body className="narrow-search-field-card" style={{'marginTop': '10px'}}>
-          <div className="narrow-search-field-title"> New Options:</div>
-          <div style={{'flex': '1', 'marginRight': '5%'}}>
-            Prevention:
-            <Select closeMenuOnSelect={false} isMulti options={preventionOptions} onChange={e => this.handleNarrowSearchChange('Prevention', e)} />
-            Transportation:
-            <Select closeMenuOnSelect={false} isMulti options={transportOptions} onChange={e => this.handleNarrowSearchChange('Transportation', e)} />
-            Recovery:
-            <Select closeMenuOnSelect={false} isMulti options={recoveryOptions} onChange={e => this.handleNarrowSearchChange('Recovery', e)} />
-            Mental Health Resources:
-            <Select closeMenuOnSelect={false} isMulti options={mentalHealthOptions} onChange={e => this.handleNarrowSearchChange('Mental Health Resources', e)} />
-            Payment:
-            <Select closeMenuOnSelect={false} isMulti options={payOptions} onChange={e => this.handleNarrowSearchChange('Payment', e)} />
-            Harm Reduction:
-            <Select closeMenuOnSelect={false} isMulti options={harmReductionOptions} onChange={e => this.handleNarrowSearchChange('Harm Reduction', e)} />
-            Pregnancy Support:
-            <Select closeMenuOnSelect={false} isMulti options={pregnancyOptions} onChange={e => this.handleNarrowSearchChange('Pregnancy Support', e)} />
-            Demographic:
-            <Select closeMenuOnSelect={false} isMulti options={demographicOptions} onChange={e => this.handleNarrowSearchChange('Demographic', e)} />
-          </div>
-        </Card.Body>
-        <Card.Body className="narrow-search-field-card" style={{'marginTop': '10px'}}>
-          <div className="narrow-search-field-title"> Resource Type:<br/>(select multiple bubbles)</div>
-          <div>
-            <div style={{'marginBottom': '20px'}}>
-              {this.renderResourceTypeButton('Prevention')}
-              {this.renderResourceTypeButton('Awareness')}
-              {this.renderResourceTypeButton('Advocacy')}
-            </div>
-            <div style={{'marginBottom': '20px'}}>
-              {this.renderResourceTypeButton('Harm Reduction')}
-              {this.renderResourceTypeButton('Naloxone Distributor')}
-              {this.renderResourceTypeButton('Overdose Response Center')}
-            </div>
-            <div>
-              {this.renderResourceTypeButton('Recovery')}
-              {this.renderResourceTypeButton('Support Groups')}
-              {this.renderResourceTypeButton('Grief/Loss')}
-            </div>
-          </div>
+          <Container>
+            <Row>
+              <Col md={4}>Prevention:</Col>
+              <Col><Select closeMenuOnSelect={false} isMulti options={preventionOptions} onChange={e => this.handleNarrowSearchChange('Prevention', e)} /></Col>
+            </Row>
+            <Row>
+              <Col md={4}>Transportation:</Col>
+              <Col><Select closeMenuOnSelect={false} isMulti options={transportOptions} onChange={e => this.handleNarrowSearchChange('Transportation', e)} /></Col>
+            </Row>
+            <Row>
+              <Col md={4}>Recovery:</Col>
+              <Col><Select closeMenuOnSelect={false} isMulti options={recoveryOptions} onChange={e => this.handleNarrowSearchChange('Recovery', e)} /></Col>
+            </Row>
+            <Row>
+              <Col md={4}>Mental Health Resources:</Col>
+              <Col><Select closeMenuOnSelect={false} isMulti options={mentalHealthOptions} onChange={e => this.handleNarrowSearchChange('Mental Health Resources', e)} /></Col>
+            </Row>
+            <Row>
+              <Col md={4}>Payment:</Col>
+              <Col><Select closeMenuOnSelect={false} isMulti options={payOptions} onChange={e => this.handleNarrowSearchChange('Payment', e)} /></Col>
+            </Row>
+            <Row>
+              <Col md={4}>Harm Reduction:</Col>
+              <Col><Select closeMenuOnSelect={false} isMulti options={harmReductionOptions} onChange={e => this.handleNarrowSearchChange('Harm Reduction', e)} /></Col>
+            </Row>
+            <Row>
+              <Col md={4}>Pregnancy Support:</Col>
+              <Col><Select closeMenuOnSelect={false} isMulti options={pregnancyOptions} onChange={e => this.handleNarrowSearchChange('Pregnancy Support', e)} /></Col>
+            </Row>
+            <Row>
+              <Col md={4}>Demographic:</Col>
+              <Col><Select closeMenuOnSelect={false} isMulti options={demographicOptions} onChange={e => this.handleNarrowSearchChange('Demographic', e)} /></Col>
+            </Row>
+          </Container>
         </Card.Body>
         <Card.Body className="narrow-search-field-card">
           <div style={{'flexDirection': 'column'}}>
@@ -273,17 +269,6 @@ class FindResource extends React.Component {
                 {this.renderTransportationButton('Center-Provided')}
               </div>
             </div>
-          </div>
-        </Card.Body>
-        <Card.Body className="narrow-search-field-card">
-          <div className="narrow-search-field-title">Demographic:</div>
-          <div>
-            {this.renderDemographicButton('Male')}
-            {this.renderDemographicButton('Female')}
-            {this.renderDemographicButton('Teen')}
-            {this.renderDemographicButton('Homeless')}
-            {this.renderDemographicButton('LGBTQ')}
-            {this.renderDemographicButton('Veteran')}
           </div>
         </Card.Body>
       </Card>

--- a/src/components/SearchResultLeftPanel/SearchResultLeftPanel.js
+++ b/src/components/SearchResultLeftPanel/SearchResultLeftPanel.js
@@ -19,7 +19,7 @@ class SearchResultLeftPanel extends  React.Component {
     resourceTypeSelection.sort();
     transportationSelection.sort();
     demographicSelection.sort();
-    
+
     return(
       <div className="search-criteria">
         <div className="criteria">
@@ -31,6 +31,13 @@ class SearchResultLeftPanel extends  React.Component {
         <div className="criteria">
           <u>Distance:</u> {distanceInMilesSelection}
         </div>
+        {
+          Object.keys(narrowSearchOptions).map((key, index) => (
+            <div className="criteria" key={index}>
+              {narrowSearchOptions[key].length > 0 && (<span><u>{key}:</u> {narrowSearchOptions[key].join(", ")}</span>)}
+            </div>
+          ))
+        }
         <div className="criteria">
           {transportationSelection.length > 0 && (<span><u>Transportation:</u> {transportationSelection.join(", ")}</span>)}
         </div>

--- a/src/components/SearchResultRightPanel/SearchResultRightPanel.css
+++ b/src/components/SearchResultRightPanel/SearchResultRightPanel.css
@@ -2,10 +2,11 @@
   width: 80%;
 }
 
-.result-card {
+#result-card {
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-  border-radius: 20px !important;
+  border-radius: 20px;
   margin-bottom: 30px;
+  border: 0px;
 }
 
 #result-card-header {

--- a/src/components/SearchResultRightPanel/SearchResultRightPanel.js
+++ b/src/components/SearchResultRightPanel/SearchResultRightPanel.js
@@ -7,7 +7,7 @@ class SearchResultRightPanel extends React.Component {
 
   renderCard = number  => {
     return(
-      <Card className="result-card">
+      <Card id="result-card">
         <Card.Header id="result-card-header">
           <span className="header-title">{`Resource ${number}`}</span>
           <span className="header-mile">5.4 mi</span>
@@ -21,14 +21,14 @@ class SearchResultRightPanel extends React.Component {
             Phone:
           </Card.Text>
           <Card.Text>
-            Services: 
+            Services:
           </Card.Text>
           <Card.Text>
             <b>Click the card for more information</b>
           </Card.Text>
         </Card.Body>
       </Card>
-    );   
+    );
   }
 
   render() {


### PR DESCRIPTION
Switched old narrow search options to new ones.

The right column is wider on large screens in order to prevent blank space (e.g. ~1900px)
![xl](https://user-images.githubusercontent.com/24534282/102000165-72a20c80-3cb2-11eb-929e-a5afcab0bd31.png)

1200px is bootstrap's highest breakpoint, so "Mental Health Resources" becomes 2 rows on some screens because of that (e.g. ~1600px).
![xls](https://user-images.githubusercontent.com/24534282/102000206-07a50580-3cb3-11eb-8e5c-1eb0570b89eb.png)

On smaller screens the labels and tags either split the screen half/half or are stacked vertically.
![mo](https://user-images.githubusercontent.com/24534282/102000291-1dff9100-3cb4-11eb-8730-2c5ea6cad9f4.png)
