### PR TITLE
Login and create account connected to backend + some frontend changes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,20 +25,73 @@ class App extends React.Component {
     super(props);
     this.state = {
       showSignInModal: false,
+      showSignOutModal: false,
       showCreateAccountModal: false,
       showResetPasswordModal: false,
       userLoggedIn: false,
       userName: '',
+      password: '',
+      email: '',
     }
   }
 
   handleLogin = (event) => {
     event.preventDefault();
+    //console.log(this.state);
+
+    fetch("/api/v1/data/users/login", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        "username": this.state.userName,
+        "password": this.state.password
+      }),
+      redirect: "follow"
+    }).then(response => response.text())
+      .then(result => console.log(result))
+      .catch(error => console.log('error', error));
+
+    // console.log(response);
     this.setState({
       showSignInModal: false,
       showResetPasswordModal: false,
       userLoggedIn: true,
+      password: '',
+      email: '',
+    });
+  }
+
+
+  handleCreateAccount = (event) => {
+    event.preventDefault();
+    //console.log(this.state);
+
+    fetch("/api/v1/data/users/register", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        "username": this.state.userName,
+        "email": this.state.email,
+        "password": this.state.password
+      }),
+      redirect: "follow"
+    }).then(response => response.text())
+      .then(result => console.log(result))
+      .catch(error => console.log('error', error));
+
+    // console.log(response);
+    this.setState({
+      showSignInModal: true,
+      showResetPasswordModal: false,
+      showCreateAccountModal: false,
+      userLoggedIn: false,
       userName: '',
+      password: '',
+      email: '',
     });
   }
 
@@ -79,13 +132,25 @@ class App extends React.Component {
         <Modal.Body>
           <Modal.Title>Welcome Back!</Modal.Title>
           <Form onSubmit={this.handleLogin}>
-            <Form.Group controlId="formBasicEmail">
-              <Form.Label>Email Address</Form.Label>
-              <Form.Control type="email" />
+            <Form.Group controlId="formBasicUsername">
+              <Form.Label>Username</Form.Label>
+              <Form.Control
+                type="text"
+                onChange={(e) => {
+                  this.setState({userName: e.target.value});
+                  // console.log(this.state);
+                }}
+              />
             </Form.Group>
             <Form.Group controlId="formBasicPassword">
               <Form.Label>Password</Form.Label>
-              <Form.Control type="password" />
+              <Form.Control
+                type="password"
+                onChange={(e) => {
+                  this.setState({password: e.target.value});
+                  // console.log(this.state);
+                }}
+              />
             </Form.Group>
             <Form.Check label="Remember my sign in" />
             <Button variant="primary" type="submit">Sign In</Button>
@@ -94,6 +159,27 @@ class App extends React.Component {
           </Form>
         </Modal.Body>
       </Modal>
+    );
+  }
+
+  renderSignOutModal = () => {
+    const { showSignOutModal } = this.state;
+
+    return (
+        <Modal show={showSignOutModal} onHide={() => this.setState({showSignOutModal: false})}>
+          <Modal.Header closeButton>
+            <Modal.Title>Sign out</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>Signed out successfully!</Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={() => this.setState({showSignOutModal: false, showSignInModal: true})}>
+              Sign in as another user
+            </Button>
+            <Button variant="danger" onClick={() => this.setState({showSignOutModal: false})}>
+              Close
+            </Button>
+          </Modal.Footer>
+        </Modal>
     );
   }
 
@@ -108,21 +194,35 @@ class App extends React.Component {
         <Modal.Body>
           <Modal.Title>Create an Account</Modal.Title>
           <Form onSubmit={this.handleCreateAccount}>
-            <Form.Group controlId="formBasicFirstName">
-              <Form.Label>First Name</Form.Label>
-              <Form.Control type="text" />
-            </Form.Group>
-            <Form.Group controlId="formBasicLastName">
-              <Form.Label>Last Name</Form.Label>
-              <Form.Control type="text" />
+            <Form.Group controlId="formBasicUsername">
+              <Form.Label>Username</Form.Label>
+              <Form.Control
+                type="text"
+                onChange={(e) => {
+                  this.setState({userName: e.target.value});
+                  // console.log(this.state);
+                }}
+              />
             </Form.Group>
             <Form.Group controlId="formBasicEmail">
               <Form.Label>Email address</Form.Label>
-              <Form.Control type="email" />
+              <Form.Control
+                type="email"
+                onChange={(e) => {
+                  this.setState({email: e.target.value});
+                  // console.log(this.state);
+                }}
+              />
             </Form.Group>
             <Form.Group controlId="formBasicPassword">
               <Form.Label>Password</Form.Label>
-              <Form.Control type="password" />
+              <Form.Control
+                type="password"
+                onChange={(e) => {
+                  this.setState({password: e.target.value});
+                  // console.log(this.state);
+                }}
+              />
             </Form.Group>
             <Form.Check label="Sign up for our newsletter to receive updates from CORA" />
             <Button variant="primary" type="submit">Sign Up!</Button>
@@ -145,6 +245,7 @@ class App extends React.Component {
         <div className="App">
           {this.renderResetPasswordModal()}
           {this.renderSignInModal()}
+          {this.renderSignOutModal()}
           {this.renderCreateAccountModal()}
           <Navbar id="main-navbar" expand="lg">
             <Navbar.Brand href="/"><Image id="cora_logo" src={cora_logo}></Image></Navbar.Brand>
@@ -165,9 +266,9 @@ class App extends React.Component {
             {userLoggedIn &&
               <div className="signed-in-content">
                 <Navbar.Collapse className="justify-content-end">
-                  <Navbar.Text>Signed in as: Dummy Name</Navbar.Text>
+                  <Navbar.Text>Signed in as: {this.state.userName.split()[0][0].toUpperCase() + this.state.userName.split()[0].substr(1).toLowerCase()}</Navbar.Text>
                 </Navbar.Collapse>
-                <Button variant="outline-dark" onClick={() => this.setState({userLoggedIn: false})}>Sign Out</Button>
+                <Button variant="outline-dark" onClick={() => this.setState({userLoggedIn: false, showSignOutModal: true})}>Sign Out</Button>
               </div>
             }
             </Navbar.Collapse>


### PR DESCRIPTION
- Login and create account connected to backend
- Changed sign in modal to ask for username and password to be consistent with backend
- Changed create account modal to ask for username, email and password since these are the only fields needed for creating an account, and the other details weren't even being stored anywhere
- After signing in, the "sign in" button changes to "Signed in as: \<username in title case\>"
- Added modal for indicating successful sign out

Changed sign in modal:
![image](https://user-images.githubusercontent.com/35015728/104993041-3455e680-59f0-11eb-81e5-2cf85f8f9314.png)

Shows "signed in as: \<username in title case\>" where the sign in button was:
![image](https://user-images.githubusercontent.com/35015728/104993103-57809600-59f0-11eb-97f0-79297f87917f.png)

Sign out modal:
![image](https://user-images.githubusercontent.com/35015728/104993133-66674880-59f0-11eb-9e38-bc5b27bd92f7.png)

Changed create account modal:
![image](https://user-images.githubusercontent.com/35015728/104993291-a1697c00-59f0-11eb-8d9d-c99c7264c9bf.png)
