### PR TITLE
results page now supports bookmarking and added some persistent user login logic

### DIFF
--- a/src/components/FindResource/FindResource.js
+++ b/src/components/FindResource/FindResource.js
@@ -164,7 +164,6 @@ class FindResource extends React.Component {
         long: lng,
         showSearchResults: true,
       }, () => {
-        console.log(`/api/v1/data/resources?lat=${lat}&long=${lng}&radius=${distanceInMilesSelection}&tags=${allTags.toString()}`);
         fetch(`/api/v1/data/resources?lat=${lat}&long=${lng}&radius=${distanceInMilesSelection}&tags=${allTags.toString()}`)
           .then(res => res.json())
           .then(results => this.setState({searchResults: results, searchError: null}))

--- a/src/components/SearchResultRightPanel/SearchResultRightPanel.css
+++ b/src/components/SearchResultRightPanel/SearchResultRightPanel.css
@@ -24,6 +24,7 @@
   font-weight: bold;
   text-align: left;
 }
+
 .header-mile {
   float: right;
 }

--- a/src/components/SearchResultRightPanel/SearchResultRightPanel.js
+++ b/src/components/SearchResultRightPanel/SearchResultRightPanel.js
@@ -1,11 +1,61 @@
 import React from 'react';
 import Card from 'react-bootstrap/Card';
+import BookmarkIcon from '@material-ui/icons/Bookmark';
+import BookmarkBorderIcon from '@material-ui/icons/BookmarkBorder';
 
 import './SearchResultRightPanel.css';
 
 const formatAddressString = (address, city, state, zipcode) => `${address} ${city}, ${state}, ${zipcode}`;
 
 class SearchResultRightPanel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      username: null,
+      bookmarks: new Set(),
+    };
+  }
+
+  componentDidMount = () => {
+    const username = localStorage.getItem('username');
+    const signedIn = localStorage.getItem('signed-in');
+    if (username && signedIn) {
+      this.setState({ username }); 
+      fetch("/api/v1/data/users/getUser", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          "username": username,
+        }),
+        redirect: "follow"
+      })
+        .then(res => res.json())
+        .then(data => {
+          const {
+            bookmarked,
+          } = data.meta;
+
+          this.setState({ bookmarks: new Set(bookmarked) });
+        })
+    }
+  }
+
+  componentDidUpdate = () => {
+    const {
+      username,
+    } = this.state;
+    const storageUsername = localStorage.getItem('username');
+
+    // user logged out on results page
+    if (username && !storageUsername) {
+      this.setState({ username: null });
+    // user logged in on results page
+    } else if (!username && storageUsername) {
+      this.setState({ username: storageUsername });
+    }
+  }
 
   renderCard = (result, index)  => {
     const {
@@ -30,8 +80,66 @@ class SearchResultRightPanel extends React.Component {
       phone,
       email
     } = contact
+    const {
+      username,
+      bookmarks,
+    } = this.state;
 
     const distanceInMiles = Math.round(distance * 100) / 100;
+    const bookmarkIconStyle = {
+      position: 'relative',
+      fontSize: 50,
+      float: 'right',
+      top: '50px',
+      marginTop: '-50px',
+      cursor: 'pointer',
+      color: '#efebb1',
+    };
+
+    const addBookmark = () => {
+      fetch("/api/v1/data/users/bookmark", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          "username": username,
+          "postID": _id,
+        }),
+        redirect: "follow"
+      })
+        .then(res => {
+          if (res.status === 200) {
+            // assigning a new set and adding the id to there so we don't modify react state directly
+            const newBookmarks = new Set(bookmarks);
+            newBookmarks.add(_id);
+            this.setState({ bookmarks: newBookmarks });
+          }
+        })
+    }
+
+    const removeBookmark = () => {
+      fetch("/api/v1/data/users/unbookmark", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          "username": username,
+          "postID": _id,
+        }),
+        redirect: "follow"
+      })
+        .then(res => {
+          if (res.status === 200) {
+            // assigning a new set and adding the id to there so we don't modify react state directly
+            const newBookmarks = new Set(bookmarks);
+            newBookmarks.delete(_id);
+            this.setState({ bookmarks: newBookmarks });
+          }
+        })
+    }
+
     return (
       <Card id="result-card" key={index}>
         <Card.Header id="result-card-header">
@@ -52,6 +160,18 @@ class SearchResultRightPanel extends React.Component {
           <Card.Text>
               <a href={`/resource-page/${_id}/${lat}/${long}`} target="_blank" rel="noopener noreferrer">Click the card for more information</a>
           </Card.Text>
+          {username && bookmarks.has(_id) &&
+            <BookmarkIcon
+              style={bookmarkIconStyle}
+              onClick={() => removeBookmark()}
+           />
+          }
+          {username && !bookmarks.has(_id) &&
+            <BookmarkBorderIcon
+              style={bookmarkIconStyle}
+              onClick={() => addBookmark()}
+           />
+          }
         </Card.Body>
       </Card>
     );


### PR DESCRIPTION
<img width="1680" alt="Screen Shot 2021-01-23 at 4 48 04 PM" src="https://user-images.githubusercontent.com/46540729/105614950-c5371400-5d9a-11eb-8b2a-3236b4b1751e.png">
bookmarking added and hooked up to backend. Bookmark icon only appears if the user is logged in. If not, then there are no icons.

Added some persistent user login logic. Cases tested for
* user clicks stay logged in --> if the browser is closed and the user comes back to the webpage,  user is still logged in until user signs out
* user signs in and opens the app in another tab --> user is still logged in until the user signs out, user closes the browser, or the user closes all tabs running the app (e.g. had 2 tabs with the app running and closed both)

1 test case I could not get to work is if on tab2, the user signs in and then refreshes tab1. The user is not logged in :angry: on tab1. It's a weird case and the user can just manually sign in again on tab1, so I'm not sure if it's worth the effort to make this work.

Let me know if there are any other tests u want me to try out. 
