### PR TITLE
fixed print map on resource page

### DIFF
--- a/src/components/ResourcePage/LeftPanel.js
+++ b/src/components/ResourcePage/LeftPanel.js
@@ -26,8 +26,10 @@ class LeftPanel extends React.Component {
     const mapStyle = {
       position: 'relative',
       minHeight: '250px',
-      width: '100%',
+      maxHeight: '1000px',
       flexGrow: '1',
+      overflow: 'visible',
+      width: '100%',
     };
 
     return (


### PR DESCRIPTION
<img width="1680" alt="Screen Shot 2021-02-06 at 8 53 58 AM" src="https://user-images.githubusercontent.com/46540729/107119982-db43da80-6858-11eb-8134-9899b1b63865.png">
Fixed by limiting `maxHeight` of the map to `1000px`.